### PR TITLE
[BUGFIX] - Fix contagem de pontos e exibição de histórico

### DIFF
--- a/main-OLD.js
+++ b/main-OLD.js
@@ -11,7 +11,6 @@ const restartButton = document.querySelector("#buttonPlayAgain");
 const revangeButton = document.querySelector("#buttonRevanche");
 const recordsButton = document.querySelector("#buttonRecords");
 const winners = [];
-const draws = [];
 let pointsPlayer1 = 0;
 let pointsPlayer2 = 0;
 let isCircleTurn;
@@ -60,20 +59,29 @@ const endGame = (isDraw) => {
 
     if (isDraw) {
         winningMessageTextElement.innerText = "Deu velha!";
-        draws.push(1);
     } else {
-        isCircleTurn ? winners.push(player1) : winners.push(player2);
-        winningMessageTextElement.innerText = `O jogador ${isCircleTurn ? player1 : player2} venceu!`;
+        if (isCircleTurn) {
+            winningMessageTextElement.innerText = `${player1} venceu!`;
+            pointsPlayer1 += 1;
+            winners.push(player1);
+        } else {
+            winningMessageTextElement.innerText = `${player2} venceu!`;
+            pointsPlayer2 += 1;
+            winners.push(player2);
+        }
     }
-    if (pointsPlayer1 === 2) {
+
+    if (pointsPlayer1 === 3) {
         revangeButton.classList.add('hidden');
         winningMessageTextElement.innerText = `O jogador ${player1} venceu 3 vezes!`;
-        setWinners({ player1, player2 })
+        setWinners({ win: player1, lose: player2 })
+        pointsPlayer1 = 0;
     }
-    if (pointsPlayer2 === 2) {
+    if (pointsPlayer2 === 3) {
         revangeButton.classList.add('hidden');
         winningMessageTextElement.innerText = `O jogador ${player2} venceu 3 vezes!`;
         setWinners({ win: player2, lose: player1 })
+        pointsPlayer2 = 0;
     }
 
     winningMessage.classList.remove("hidden");
@@ -125,19 +133,14 @@ const setPlayers = () => {
     player1Element.children[0].innerText = player1;
     player2Element.children[0].innerText = player2;
 
-    pointsPlayer1 = 0;
-    pointsPlayer2 = 0;
-
-    if (pointsPlayer1 === 2 || pointsPlayer2 === 2) {
+    if (pointsPlayer1 === 3 || pointsPlayer2 === 3) {
         winners.splice(0, winners.length);
     }
 
     winners.find(winner => {
         if (winner === player1) {
-            pointsPlayer1 += 1;
             player1Element.children[1].innerText = `Placar: ${pointsPlayer1}`;
         } else if (winner === player2) {
-            pointsPlayer2 += 1;
             player2Element.children[1].innerText = `Placar: ${pointsPlayer2}`;
         }
     });

--- a/records.html
+++ b/records.html
@@ -15,12 +15,10 @@
         <thead>
             <tr>
                 <th class="table-th">Vencedores</th>
-                <th class="table-th">Velhas</th>
+                <th class="table-th">Perdedores</th>
             </tr>
         </thead>
         <tbody class="table-tbody win">
-            <tr id="winners"></tr>
-            <tr id="draws"></tr>
         </tbody>
     </table>
     <div>

--- a/records.js
+++ b/records.js
@@ -1,11 +1,7 @@
 const record = document.querySelector('.win');
 function getRecords() {
     const records = JSON.parse(localStorage.getItem('winners'));
-    console.log(records)
     records.map(({ win, lose }, index) => {
-        console.log(index)
-        console.log(win)
-        console.log(lose)
         setTimeout(() => {
             record.innerHTML = record.innerHTML +
                 `


### PR DESCRIPTION
## O que foi feito? 📝

- Corrigido contagem de pontos dos jogadores que assim que um dos jogadores tinha 2 pontos encerrava na próxima interação, desconsiderando pontuação do oponente.
- Corrigido bug que ignorava nome do campeão da partida se fosse o player1
- Alterado campo Velhas para Perdedores no histórico das partidas.

## Screenshots ou GIFs 📸

![image](https://user-images.githubusercontent.com/66846993/162754173-0d2565ed-1e05-4971-a675-001cd17b8293.png)

| -----Figma----- | -Implementação- |
| :-------------: | :-------------: |
| <!----aqui----> | <!----aqui----> |

## Como testar 🧪

- Roda o código aí e se vira ;)

## Checklist 🧐

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [X] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨
